### PR TITLE
Add installation section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # nextjs-backend-helpers
 
+## Installation
+
+```bash
+yarn add nextjs-backend-helpers
+```
+
+or
+
+```bash
+npm i nextjs-backend-helpers
+```
+
+## Description
+
 A collection of helpers designed to make fullstack NextJS services easier to create. There are helpers to register API style `controllers`, a database `Repository` class designed to work with [`Prisma`](https://www.prisma.io/), and even testing tools.
 
 ## The Problem


### PR DESCRIPTION
# Description

 Hi Adam! 

I'm building a nextjs app for a new small business idea I came up with :P so I thought I'd give your backend helpers a try.

Anywho - this just adds a super quick section at the head of the README to point us at the correct name for the installation (I usualy copy that bit from readme), since the name of the repo is `big-weaver`, but the packages is `nextjs-backend-helpers`.

# Results

 - ✨ minor addition to the readme ✨ 